### PR TITLE
Fix web UI rendering after queue update

### DIFF
--- a/val-server/frontend/App.tsx
+++ b/val-server/frontend/App.tsx
@@ -128,9 +128,10 @@ function AuthenticatedApp() {
         if (response.ok) {
           const data = await response.json();
 
-          if (data.status === "updated" && data.content) {
-            setCurrentContent(data.content);
-          } else if (data.status === "clear") {
+          if (data.status === "updated" && data.playlist && data.playlist.length > 0) {
+            // Use first item from playlist
+            setCurrentContent(data.playlist[0]);
+          } else if (data.status === "clear" || (data.status === "updated" && (!data.playlist || data.playlist.length === 0))) {
             setCurrentContent(null);
             setDisplayBits(new Array(28 * 14).fill(0));
           }


### PR DESCRIPTION
The backend API changed to return a playlist array instead of a single content object, but the frontend was still looking for data.content.

Updated App.tsx to:
- Check for data.playlist instead of data.content
- Use the first item from the playlist (data.playlist[0])
- Handle empty playlist case properly

This fixes the rendering issue introduced in commit 943e3cf.